### PR TITLE
feat: bigint literals without as const

### DIFF
--- a/sources/index.ts
+++ b/sources/index.ts
@@ -88,6 +88,7 @@ export function isLiteral(expected: null): StrictValidator<unknown, null>;
 export function isLiteral(expected: true): StrictValidator<unknown, true>;
 export function isLiteral(expected: false): StrictValidator<unknown, false>;
 export function isLiteral<T extends number>(expected: T): StrictValidator<unknown, T>;
+export function isLiteral<T extends bigint>(expected: T): StrictValidator<unknown, T>;
 export function isLiteral<T extends string>(expected: T): StrictValidator<unknown, T>;
 export function isLiteral<T>(expected: T): StrictValidator<unknown, T>;
 export function isLiteral<T>(expected: T) {
@@ -732,7 +733,7 @@ export const hasKeyRelationship = (subject: string, relationship: KeyRelationshi
 
       if (problems.length >= 1)
         return pushError(state, `Property "${subject}" ${spec.message} ${plural(problems.length, `property`, `properties`)} ${problems.map(name => `"${name}"`).join(`, `)}`);
-      
+
       return true;
     },
   })

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "es2020"
+  }
+}

--- a/tests/type-guards.ts
+++ b/tests/type-guards.ts
@@ -25,6 +25,10 @@ import * as t from '../sources';
     if (t.isLiteral(42)(foo)) {
         const bar: 42 = foo;
     }
+
+    if (t.isLiteral(42n)(foo)) {
+        const bar: 42n = foo;
+    }
 }
 
 (foo: unknown) => {


### PR DESCRIPTION
`t.isLiteral` didn't support bigint literals without `as const`.