### PR TITLE
Adds coercion support for arrays

### DIFF
--- a/sources/index.ts
+++ b/sources/index.ts
@@ -228,8 +228,18 @@ export const isDate = () => makeValidator<unknown, Date>({
   },
 });
 
-export const isArray = <T extends AnyStrictValidator>(spec: T) => makeValidator<unknown, Array<InferType<T>>>({
+export const isArray = <T extends AnyStrictValidator>(spec: T, {delimiter}: {delimiter?: string | RegExp} = {}) => makeValidator<unknown, Array<InferType<T>>>({
   test: (value, state): value is Array<InferType<T>> => {
+    if (typeof value === `string` && typeof delimiter !== `undefined`) {
+      if (typeof state?.coercions !== `undefined`) {
+        if (typeof state?.coercion === `undefined`)
+          return pushError(state, `Unbound coercion result`);
+
+        value = value.split(delimiter);
+        state.coercions.push([state.p ?? `.`, state.coercion.bind(null, value)]);
+      }
+    }
+
     if (!Array.isArray(value))
       return pushError(state, `Expected an array (got ${getPrintable(value)})`);
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -309,6 +309,16 @@ const COERCION_TESTS: {
     [[`true`], [], [true]],
   ],
 }, {
+  validator: () => t.isObject({foo: t.isArray(t.isBoolean(), {delimiter: /,/})}),
+  tests: [
+    [{foo: `true`}, [], {foo: [true]}],
+  ],
+}, {
+validator: () => t.isObject({foo: t.isArray(t.isBoolean(), {delimiter: /,/})}),
+  tests: [
+    [{foo: `true,false`}, [], {foo: [true, false]}],
+  ],
+}, {
   validator: () => t.isDict(t.isBoolean()),
   tests: [
     [{foo: `true`}, [], {foo: true}],

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -314,7 +314,7 @@ const COERCION_TESTS: {
     [{foo: `true`}, [], {foo: [true]}],
   ],
 }, {
-validator: () => t.isObject({foo: t.isArray(t.isBoolean(), {delimiter: /,/})}),
+  validator: () => t.isObject({foo: t.isArray(t.isBoolean(), {delimiter: /,/})}),
   tests: [
     [{foo: `true,false`}, [], {foo: [true, false]}],
   ],


### PR DESCRIPTION
This diff adds support for coercing strings into array by splitting them on a delimiter. It can be useful with things like Clipanion, where you might want to implement an array option using a syntax like `--ext .js,.jsx,.ts,.tsx`.