### PR TITLE
fix: Fix isDict only validating the first key in an object.

### DIFF
--- a/sources/index.ts
+++ b/sources/index.ts
@@ -335,7 +335,7 @@ export const isDict = <T extends AnyStrictValidator>(spec: T, {
     const keys = Object.keys(value);
 
     let valid = true;
-    for (let t = 0, T = keys.length && (valid || state?.errors != null); t < T; ++t) {
+    for (let t = 0, T = keys.length; t < T && (valid || state?.errors != null); ++t) {
       const key = keys[t];
       const sub = (value as {[key: string]: unknown})[key];
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -128,6 +128,9 @@ const VALIDATION_TESTS: {
     [{}, true],
     [{foo: 42}, true],
     [{foo: `foo`}, false],
+    [{foo: 42, bar: 42}, true],
+    [{foo: 42, bar: `bar`}, false],
+    [{foo: `foo`, bar: 42}, false],
     [42, false],
   ],
 }, {


### PR DESCRIPTION
Hi,
Per the title, I noticed that `isDict` is only validating the first key in an object.

Looks like a typo, the check for existing errors at the top of the loop was placed on the wrong expression. Sans fix, the additional test cases in `tests/index.test.ts` produce the following failure:
```
  1) Validation Tests
       Validation for () => t.isDict(t.isNumber())
         it should disallow {"foo":42,"bar":"bar"}:

      AssertionError: expected true to equal false
      + expected - actual

      -true
      +false
      
      at Context.<anonymous> (tests/index.test.ts:189:36)
      at processImmediate (node:internal/timers:464:21)
```