### PR TITLE
switch to @rollup/plugin-typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "website"
   ],
   "devDependencies": {
+    "@rollup/plugin-typescript": "^8.2.1",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^7.0.2",
-    "@wessberg/rollup-plugin-ts": "^1.2.25",
     "chai": "^4.2.0",
     "mocha": "^8.0.1",
     "rollup": "^2.17.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,14 +1,16 @@
-import ts from "@wessberg/rollup-plugin-ts";
+import ts from "@rollup/plugin-typescript";
 
 export default {
   input: './sources/index.ts',
   output: [
     {
-      file: 'lib/index.mjs',
+      dir: 'lib',
+      entryFileNames: '[name].mjs',
       format: 'es'
     },
     {
-      file: 'lib/index.js',
+      dir: 'lib',
+      entryFileNames: '[name].js',
       format: 'cjs'
     },
   ],

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": false
+    "noEmit": false,
+    "rootDir": "sources",
+    "outDir": "lib",
   },
   "include": [
     "sources/**/*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     ],
     "module": "commonjs",
     "noEmit": true,
-    "outDir": "lib",
     "strict": true,
     "target": "es2017"
   },


### PR DESCRIPTION
`@rollup/plugin-typescript` is maintained by the rollup community so has better support.
Clipanion already switched from `@wessberg/rollup-plugin-ts` to `@rollup/plugin-typescript` , so I think this switch is quite necessary.
Also, these changes will be very helpful to dependents of typanion.