### PR TITLE
fix: Fix isISO8601 always returning false.

### DIFF
--- a/sources/index.ts
+++ b/sources/index.ts
@@ -700,7 +700,7 @@ export const isISO8601 = () => makeValidator<string>({
     if (!iso8601RegExp.test(value))
       return pushError(state, `Expected to be a valid ISO 8601 date string (got ${getPrintable(value)})`);
 
-    return false;
+    return true;
   },
 });
 


### PR DESCRIPTION
Hi,
I noticed there's a typo in `isISO8601` making it always fail, regardless of the input.