### PR TITLE
fix: Fix isLiteral error message complaining about the wrong value.

### DIFF
--- a/sources/index.ts
+++ b/sources/index.ts
@@ -105,7 +105,7 @@ export function isLiteral<T>(expected: T) {
   return makeValidator<unknown, T>({
     test: (value, state): value is T => {
       if (value !== expected)
-        return pushError(state, `Expected a literal (got ${getPrintable(expected)})`);
+        return pushError(state, `Expected a literal (got ${getPrintable(value)})`);
 
       return true;
     },


### PR DESCRIPTION
Hi,
I found an issue where `isLiteral` would complain about the expected value rather than the received value in its error messages.