### PR TITLE
Fix main field to be compatible with nodenext module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typanion",
   "version": "3.7.1",
-  "main": "sources/index",
+  "main": "sources/index.js",
   "license": "MIT",
   "sideEffects": false,
   "repository": {


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript/issues/46770#issuecomment-966612103 for detail, in `nodenext` module resolution it requires a full filename including extension