### PR TITLE
Fix `hasMutuallyExclusiveKeys` to handle Clipanion

### DIFF
--- a/sources/predicates/helperPredicates.ts
+++ b/sources/predicates/helperPredicates.ts
@@ -191,26 +191,26 @@ export function hasAtLeastOneKey(requiredKeys: string[]) {
    });
  }
  
- export type MissingType = 'missing' | 'undefined' | 'nil' | 'falsy';
+const checks = {
+  missing: (key: string) => keys.has(key),
+  undefined: (key: string) => keys.has(key) && typeof value[key] !== `undefined`,
+  nil: (key: string) => keys.has(key) && value[key] != null,
+  falsy: (key: string) => keys.has(key) && !!value[key],
+};
 
- /**
-  * Create a validator that checks that the tested object contains at most one
-  * of the specified keys.
-*/
+export type MissingType = keyof typeof checks;
+
+/**
+ * Create a validator that checks that the tested object contains at most one
+ * of the specified keys.
+ */
 export function hasMutuallyExclusiveKeys(exclusiveKeys: string[], options?: { missingIf: MissingType }) {
   const exclusiveSet = new Set(exclusiveKeys);
+  const check = checks[options?.missingIf ?? 'missing'];
 
   return makeValidator<{[key: string]: unknown}>({
     test: (value, state) => {
       const keys = new Set(Object.keys(value));
-      const checks: {[index in MissingType]: (key: string) => boolean } = {
-        missing: (key: string) => keys.has(key),
-        undefined: (key: string) => keys.has(key) && typeof value[key] !== `undefined`,
-        nil: (key: string) => keys.has(key) && value[key] != null,
-        falsy: (key: string) => keys.has(key) && !!value[key],
-      };
-
-      const check: (key: string) => boolean = checks[options?.missingIf ?? 'missing'];
 
       const used: string[] = [];
       for (const key of exclusiveSet)

--- a/sources/predicates/helperPredicates.ts
+++ b/sources/predicates/helperPredicates.ts
@@ -195,7 +195,7 @@ export type MissingType = 'missing' | 'undefined' | 'nil' | 'falsy';
  
 const checks: {[index in MissingType]: (keys: Set<string>, key: string, value: Record<string, unknown>) => boolean } = {
   missing: (keys, key) => keys.has(key),
-  undefined: (key, key, value) => keys.has(key) && typeof value[key] !== `undefined`,
+  undefined: (keys, key, value) => keys.has(key) && typeof value[key] !== `undefined`,
   nil: (keys, key, value) => keys.has(key) && value[key] != null,
   falsy: (keys, key, value) => keys.has(key) && !!value[key],
 };

--- a/sources/predicates/helperPredicates.ts
+++ b/sources/predicates/helperPredicates.ts
@@ -191,14 +191,14 @@ export function hasAtLeastOneKey(requiredKeys: string[]) {
    });
  }
  
-const checks = {
-  missing: (key: string) => keys.has(key),
-  undefined: (key: string) => keys.has(key) && typeof value[key] !== `undefined`,
-  nil: (key: string) => keys.has(key) && value[key] != null,
-  falsy: (key: string) => keys.has(key) && !!value[key],
+export type MissingType = 'missing' | 'undefined' | 'nil' | 'falsy';
+ 
+const checks: {[index in MissingType]: (keys: Set<string>, key: string, value: Record<string, unknown>) => boolean } = {
+  missing: (keys, key) => keys.has(key),
+  undefined: (key, key, value) => keys.has(key) && typeof value[key] !== `undefined`,
+  nil: (keys, key, value) => keys.has(key) && value[key] != null,
+  falsy: (keys, key, value) => keys.has(key) && !!value[key],
 };
-
-export type MissingType = keyof typeof checks;
 
 /**
  * Create a validator that checks that the tested object contains at most one
@@ -214,7 +214,7 @@ export function hasMutuallyExclusiveKeys(exclusiveKeys: string[], options?: { mi
 
       const used: string[] = [];
       for (const key of exclusiveSet)
-        if (check(key))
+        if (check(keys, key, value))
           used.push(key);
 
       if (used.length > 1)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -310,6 +310,52 @@ const ERROR_TESTS: {
   tests: [
     [{foo: 42}, []],
     [{bar: 42}, []],
+    [{foo: undefined, bar: null}, [`.: Mutually exclusive properties "foo" and "bar"`]],
+    [{foo: false, bar: null}, [`.: Mutually exclusive properties "foo" and "bar"`]],
+    [{foo: 42, bar: 42, baz: 42}, [`.: Mutually exclusive properties "foo" and "bar"`]],
+    [{baz: 42}, []],
+  ],
+}, {
+  validator: () => t.cascade(t.isRecord(t.isUnknown()), [t.hasMutuallyExclusiveKeys([`foo`, `bar`], { missingIf: 'missing' })]),
+  tests: [
+    [{foo: 42}, []],
+    [{bar: 42}, []],
+    [{foo: undefined, bar: null}, [`.: Mutually exclusive properties "foo" and "bar"`]],
+    [{foo: false, bar: null}, [`.: Mutually exclusive properties "foo" and "bar"`]],
+    [{foo: false, bar: 0}, [`.: Mutually exclusive properties "foo" and "bar"`]],
+    [{foo: 42, bar: 42, baz: 42}, [`.: Mutually exclusive properties "foo" and "bar"`]],
+    [{baz: 42}, []],
+  ],
+}, {
+  validator: () => t.cascade(t.isRecord(t.isUnknown()), [t.hasMutuallyExclusiveKeys([`foo`, `bar`], { missingIf: 'undefined' })]),
+  tests: [
+    [{foo: 42}, []],
+    [{bar: 42}, []],
+    [{foo: undefined, bar: null}, []],
+    [{foo: false, bar: null}, [`.: Mutually exclusive properties "foo" and "bar"`]],
+    [{foo: false, bar: 0}, [`.: Mutually exclusive properties "foo" and "bar"`]],
+    [{foo: 42, bar: 42, baz: 42}, [`.: Mutually exclusive properties "foo" and "bar"`]],
+    [{baz: 42}, []],
+  ],
+}, {
+  validator: () => t.cascade(t.isRecord(t.isUnknown()), [t.hasMutuallyExclusiveKeys([`foo`, `bar`], { missingIf: 'nil' })]),
+  tests: [
+    [{foo: 42}, []],
+    [{bar: 42}, []],
+    [{foo: undefined, bar: null}, []],
+    [{foo: false, bar: null}, []],
+    [{foo: false, bar: 0}, [`.: Mutually exclusive properties "foo" and "bar"`]],
+    [{foo: 42, bar: 42, baz: 42}, [`.: Mutually exclusive properties "foo" and "bar"`]],
+    [{baz: 42}, []],
+  ],
+}, {
+  validator: () => t.cascade(t.isRecord(t.isUnknown()), [t.hasMutuallyExclusiveKeys([`foo`, `bar`], { missingIf: 'falsy' })]),
+  tests: [
+    [{foo: 42}, []],
+    [{bar: 42}, []],
+    [{foo: undefined, bar: null}, []],
+    [{foo: false, bar: null}, []],
+    [{foo: false, bar: 0}, []],
     [{foo: 42, bar: 42, baz: 42}, [`.: Mutually exclusive properties "foo" and "bar"`]],
     [{baz: 42}, []],
   ],

--- a/website/docs/predicates/cascading.md
+++ b/website/docs/predicates/cascading.md
@@ -70,11 +70,19 @@ Ensure that the values all have a `length` property at least equal to the specif
 ```ts twoslash
 import * as t from 'typanion';
 declare const keys: Array<string>;
+declare const options: { missingIf: t.MissingType }
 // ---cut---
-const validate = t.hasMutuallyExclusiveKeys(keys);
+const validate = t.hasMutuallyExclusiveKeys(keys, options?);
 ```
 
-Ensure that the objects don't contain more than one of the specified keys.
+Ensure that the objects don't contain more than one of the specified keys. Keys will be considered missing based on `options.missingIf`.
+
+Options:
+- `missingIf`:
+  - `missing` (default): the key isn't present.
+  - `undefined`: the key is `undefined`.
+  - `nil`: the key is either `undefined` or `null`.
+  - `falsy`: the key has a falsy value (ex: `0`, `false`, `undefined`, `null`)
 
 ## `hasRequiredKeys`
 


### PR DESCRIPTION
### Problem:

When used in Clipanion's schema, `t.hasMutuallyExclusiveKeys` wouldn't work as expected.
Keys are all set as `undefined` making it flag the keys regardless of their definition.

### Solution:

Add an `option.missingIf` parameter so we can decide which keys to consider as actually missing.
4 options possible:
  - `missing` (default): the key isn't present.
  - `undefined`: the key is `undefined`.
  - `nil`: the key is either `undefined` or `null`.
  - `falsy`: the key has a falsy value (ex: `0`, `false`, `undefined`, `null`)
