### PR TITLE
fix: add `module` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "test": "yarn tsc && TS_NODE_TRANSPILE_ONLY=true mocha --require ts-node/register --extension ts tests/**/*.test.ts"
   },
   "publishConfig": {
-    "main": "lib/index"
+    "main": "lib/index",
+    "module": "lib/index.mjs"
   },
   "files": [
     "lib"


### PR DESCRIPTION
**What's the problem this PR addresses?**

esbuild, by default, doesn't look for `.mjs` extensions so it picks the commonjs file which it wont tree-shake.

**How did you fix it?**

Added a `module` field pointing to the `.mjs` file.